### PR TITLE
Using custom ART error profiles

### DIFF
--- a/defaults/default_config.ini
+++ b/defaults/default_config.ini
@@ -54,7 +54,7 @@ profile=mbarc
 error_profiles=tools/art_illumina-2.3.6/profiles/
 
 # For supplying custom error profiles with "own" option:
-# "base name" of error profile files (without "[1/2].txt")
+# path to error profile files (without "[1/2].txt")
 base_profile_name=
 # read length for custom error profile
 profile_read_length=

--- a/defaults/default_config.ini
+++ b/defaults/default_config.ini
@@ -44,6 +44,7 @@ readsim=tools/art_illumina-2.3.6/art_illumina
 #for ART:
 #HiSeq 150bp: hi150
 #MBARC-26 150bp: mbarc
+#custom profile (see below): own
 #for wgsim:
 #error rate as <float> (e.g. 0.05 for 5% error rate)
 #blank for nanosim and wgsim
@@ -51,6 +52,12 @@ profile=mbarc
 
 # Directory containing error profiles (can be blank for wgsim)
 error_profiles=tools/art_illumina-2.3.6/profiles/
+
+# For supplying custom error profiles with "own" option:
+# "base name" of error profile files (without "[1/2].txt")
+base_profile_name=
+# read length for custom error profile
+profile_read_length=
 
 #paired end read, insert size (not applicable for nanosim)
 fragments_size_mean=270

--- a/metagenomesimulation.py
+++ b/metagenomesimulation.py
@@ -336,14 +336,27 @@ class MetagenomeSimulation(ArgumentHandler):
             tmp_dir=self._project_file_folder_handler.get_tmp_wd())
 
         file_path_genome_locations = self._project_file_folder_handler.get_genome_location_file_path()
-        simulator.simulate(
-            file_path_distribution=file_path_distribution,
-            file_path_genome_locations=file_path_genome_locations,
-            directory_output=directory_output_tmp,
-            total_size=self._sample_size_in_base_pairs,
-            profile=self._error_profile,
-            fragment_size_mean=self._fragments_size_mean_in_bp,
-            fragment_size_standard_deviation=self._fragment_size_standard_deviation_in_bp)
+        # TODO: fix clumsy implementation
+        if self._read_simulator_type == "art":
+            simulator.simulate(
+                file_path_distribution=file_path_distribution,
+                file_path_genome_locations=file_path_genome_locations,
+                directory_output=directory_output_tmp,
+                total_size=self._sample_size_in_base_pairs,
+                profile=self._error_profile,
+                fragment_size_mean=self._fragments_size_mean_in_bp,
+                fragment_size_standard_deviation=self._fragment_size_standard_deviation_in_bp,
+                profile_filename=self._custom_profile_filename,
+                own_read_length=self._custom_readlength)
+        else:
+            simulator.simulate(
+                file_path_distribution=file_path_distribution,
+                file_path_genome_locations=file_path_genome_locations,
+                directory_output=directory_output_tmp,
+                total_size=self._sample_size_in_base_pairs,
+                profile=self._error_profile,
+                fragment_size_mean=self._fragments_size_mean_in_bp,
+                fragment_size_standard_deviation=self._fragment_size_standard_deviation_in_bp)
 
         # convert sam to bam
         samtools = SamtoolsWrapper(

--- a/metagenomesimulation.py
+++ b/metagenomesimulation.py
@@ -336,7 +336,6 @@ class MetagenomeSimulation(ArgumentHandler):
             tmp_dir=self._project_file_folder_handler.get_tmp_wd())
 
         file_path_genome_locations = self._project_file_folder_handler.get_genome_location_file_path()
-        # TODO: fix clumsy implementation
         if self._read_simulator_type == "art":
             simulator.simulate(
                 file_path_distribution=file_path_distribution,

--- a/scripts/ReadSimulationWrapper/readsimulationwrapper.py
+++ b/scripts/ReadSimulationWrapper/readsimulationwrapper.py
@@ -723,12 +723,13 @@ class ReadSimulationArt(ReadSimulationWrapper):
             assert isinstance(own_read_length, (int, long)), "Expected natural digit for read length"
             assert own_read_length > 0, "Read length must be a positive number"
             assert profile_filename, "Profile filename must be given when supplying own profile"
-            # check if supplied file is present
+            # check if supplied files are present
             own_filenames = [
                 profile_filename+file_end
                 for file_end in ['1.txt', '2.txt']
             ]
             assert self.validate_dir(self._directory_error_profiles, file_names=own_filenames)
+            # add user-supplied profiles
             self._art_error_profiles["own"] = profile_filename
             self._art_read_length["own"] = own_read_length
         if profile is not None:

--- a/scripts/ReadSimulationWrapper/readsimulationwrapper.py
+++ b/scripts/ReadSimulationWrapper/readsimulationwrapper.py
@@ -10,6 +10,7 @@ import os
 import random
 import argparse
 import tempfile
+import string
 import StringIO
 from scripts.parallel import TaskCmd, runCmdParallel, reportFailedCmd
 from scripts.MetaDataTable.metadatatable import MetadataTable
@@ -723,6 +724,9 @@ class ReadSimulationArt(ReadSimulationWrapper):
             assert isinstance(own_read_length, (int, long)), "Expected natural digit for read length"
             assert own_read_length > 0, "Read length must be a positive number"
             assert profile_filename, "Profile filename must be given when supplying own profile"
+            # sanity check file name
+            legal_for_filename = string.ascii_letters + string.digits + '_-.'
+            assert self.validate_characters(profile_filename, legal_alphabet=legal_for_filename)
             # check if supplied files are present
             own_filenames = [
                 profile_filename+file_end

--- a/scripts/ReadSimulationWrapper/readsimulationwrapper.py
+++ b/scripts/ReadSimulationWrapper/readsimulationwrapper.py
@@ -725,14 +725,16 @@ class ReadSimulationArt(ReadSimulationWrapper):
             assert own_read_length > 0, "Read length must be a positive number"
             assert profile_filename, "Profile filename must be given when supplying own profile"
             # sanity check file name
-            legal_for_filename = string.ascii_letters + string.digits + '_-.'
+            legal_for_filename = string.ascii_letters + string.digits + '_-./\\'
             assert self.validate_characters(profile_filename, legal_alphabet=legal_for_filename)
             # check if supplied files are present
             own_filenames = [
                 profile_filename+file_end
                 for file_end in ['1.txt', '2.txt']
             ]
-            assert self.validate_dir(self._directory_error_profiles, file_names=own_filenames)
+            #assert self.validate_dir(self._directory_error_profiles, file_names=own_filenames)
+            for own_file in own_filenames:
+                assert self.validate_file(own_file)
             # add user-supplied profiles
             self._art_error_profiles["own"] = profile_filename
             self._art_read_length["own"] = own_read_length

--- a/scripts/ReadSimulationWrapper/readsimulationwrapper.py
+++ b/scripts/ReadSimulationWrapper/readsimulationwrapper.py
@@ -685,7 +685,8 @@ class ReadSimulationArt(ReadSimulationWrapper):
 
     def simulate(
         self, file_path_distribution, file_path_genome_locations, directory_output,
-        total_size, profile, fragment_size_mean, fragment_size_standard_deviation):
+        total_size, profile, fragment_size_mean, fragment_size_standard_deviation,
+        profile_filename=None, own_read_length=None):
         """
         Simulate reads based on a given sample distribution
 
@@ -697,12 +698,16 @@ class ReadSimulationArt(ReadSimulationWrapper):
         @type directory_output: str | unicode
         @param total_size: Size of sample in base pairs
         @type total_size: int | long
-        @param profile: Art illumina error profile: 'low', 'mi', 'hi', 'hi150'
+        @param profile: Art illumina error profile: 'low', 'mi', 'hi', 'hi150', 'own'
         @type profile: str | unicode
         @param fragment_size_mean: Size of the fragment of which the ends are used as reads in base pairs
         @type fragment_size_mean: int | long
         @param fragment_size_standard_deviation: Standard deviation of the fragment size in base pairs.
         @type fragment_size_standard_deviation: int | long
+        @param profile_filename: Optional base name of user-supplied error profile files (without "[1/2].txt").
+        @type profile_filename: str | unicode | None
+        @param own_read_length: Optional read length for user-supplied error profile.
+        @type own_read_length: int | long | None
         """
         assert isinstance(total_size, (int, long)), "Expected natural digit"
         assert isinstance(fragment_size_mean, (int, long)), "Expected natural digit"
@@ -711,6 +716,21 @@ class ReadSimulationArt(ReadSimulationWrapper):
         assert fragment_size_mean > 0, "Mean fragments size needs to be a positive number"
         assert fragment_size_standard_deviation > 0, "Fragment size standard deviation needs to be a positive number"
         assert self.validate_dir(directory_output)
+        # if user specifies own profile, add corresponding parameters
+        if profile == "own":
+            # sanity checks
+            assert own_read_length, "Read length must be given when supplying own profile"
+            assert isinstance(own_read_length, (int, long)), "Expected natural digit for read length"
+            assert own_read_length > 0, "Read length must be a positive number"
+            assert profile_filename, "Profile filename must be given when supplying own profile"
+            # check if supplied file is present
+            own_filenames = [
+                profile_filename+file_end
+                for file_end in ['1.txt', '2.txt']
+            ]
+            assert self.validate_dir(self._directory_error_profiles, file_names=own_filenames)
+            self._art_error_profiles["own"] = profile_filename
+            self._art_read_length["own"] = own_read_length
         if profile is not None:
             assert profile in self._art_error_profiles, "Unknown art illumina profile: '{}'".format(profile)
             assert profile in self._art_read_length,  "Unknown art illumina profile: '{}'".format(profile)

--- a/scripts/configfilehandler.py
+++ b/scripts/configfilehandler.py
@@ -91,7 +91,7 @@ class ConfigFileHandler(DefaultValues):
 
         if self._error_profile is None:
             self._error_profile = self._config.get_value("profile", silent=True)
-
+            
         if self._custom_profile_filename is None:
             self._custom_profile_filename = self._config.get_value("base_profile_name", silent=True)
         

--- a/scripts/configfilehandler.py
+++ b/scripts/configfilehandler.py
@@ -92,6 +92,12 @@ class ConfigFileHandler(DefaultValues):
         if self._error_profile is None:
             self._error_profile = self._config.get_value("profile", silent=True)
 
+        if self._custom_profile_filename is None:
+            self._custom_profile_filename = self._config.get_value("base_profile_name", silent=True)
+        
+        if self._custom_readlength is None:
+            self._custom_readlength = self._config.get_value("profile_read_length", silent=True)
+
         if self._fragment_size_standard_deviation_in_bp is None:
             self._fragment_size_standard_deviation_in_bp = self._config.get_value(
                 "fragment_size_standard_deviation", is_digit=True, silent=True)

--- a/scripts/configfilehandler.py
+++ b/scripts/configfilehandler.py
@@ -96,7 +96,7 @@ class ConfigFileHandler(DefaultValues):
             self._custom_profile_filename = self._config.get_value("base_profile_name", silent=True)
         
         if self._custom_readlength is None:
-            self._custom_readlength = self._config.get_value("profile_read_length", silent=True)
+            self._custom_readlength = self._config.get_value("profile_read_length", is_digit=True, silent=True)
 
         if self._fragment_size_standard_deviation_in_bp is None:
             self._fragment_size_standard_deviation_in_bp = self._config.get_value(
@@ -209,6 +209,8 @@ class ConfigFileHandler(DefaultValues):
         output_stream.write("error_profiles={}\n".format(self._directory_error_profiles or ""))
         output_stream.write("samtools={}\n".format(self._executable_samtools))
         output_stream.write("profile={}\n".format(self._error_profile))
+        output_stream.write("base_profile_name={}\n".format(self._custom_profile_filename or ""))
+        output_stream.write("profile_read_length={}\n".format(self._custom_readlength or ""))
         output_stream.write("size={}\n".format(self._sample_size_in_base_pairs/self._base_pairs_multiplication_factor))
         output_stream.write("type={}\n".format(self._read_simulator_type))
         output_stream.write("fragments_size_mean={}\n".format(self._fragments_size_mean_in_bp))

--- a/scripts/defaultvalues.py
+++ b/scripts/defaultvalues.py
@@ -59,6 +59,8 @@ class DefaultValues(DefaultLogging):
 
     _read_simulator_type = None
     _error_profile = None
+    _custom_profile_filename = None
+    _custom_readlength = None
     _fragment_size_standard_deviation_in_bp = None
     _fragments_size_mean_in_bp = None
 


### PR DESCRIPTION
Over the last months, we've been using CAMISIM a lot and ended up needing a way to use ART error profiles from our own data with it - I thought this could be something that's interesting for you to have in CAMISIM proper, too.

It works by having the user specify "own" instead of mbarc/hi150/hi/mi as the profile name in the config file, and then there's two additional parameters for the "base name" of the profile files (without "[1/2].txt", like e.g. "HiSeq2500L150R" for the existing hi150 profile) as well as the read length. 
I've added the corresponding parameters to default_config.ini, just for illustration/documentation purposes, but of course it's still compatible with config files that don't have these parameters. 