### PR TITLE
Fixed error: locate Perl module

### DIFF
--- a/scripts/StrainSimulationWrapper/sgEvolver/simujobrun.pl
+++ b/scripts/StrainSimulationWrapper/sgEvolver/simujobrun.pl
@@ -8,6 +8,8 @@
 use strict;
 use POSIX;
 use File::Basename;
+use FindBin;
+use lib "$FindBin::Bin/simulation_dir";
 require simujobparams;
 
 if( @ARGV < 3 ){


### PR DESCRIPTION
Hi and sorry to bother you again!
I have just made one last change to fix the error in locating the Perl module `simujobparams.pm` that occurs during strain simulation in the _de novo_ mode (I mentioned this error in Issue #132).
I hope this will be useful!