### PR TITLE
Use coverage for NanoSim long-read simulations

### DIFF
--- a/pipelines/metagenomic/read_simulators/read_simulator_nansoim3.nf
+++ b/pipelines/metagenomic/read_simulators/read_simulator_nansoim3.nf
@@ -50,7 +50,7 @@ process simulate_reads_fasta_nanosim3 {
     conda 'conda-forge::scikit-learn=0.23.2 conda-forge::numpy=1.23.5 bioconda::nanosim=3.2'
 	
     input:
-    tuple val(genome_id), val(sample_id), path(fasta_file), val(abundance), val (seed)
+    tuple val(genome_id), val(sample_id), path(fasta_file), val(abundance), val (seed), val(genome_size)
     val(read_length_ch)
     
     output:
@@ -59,8 +59,8 @@ process simulate_reads_fasta_nanosim3 {
     script:
     total_size = new BigDecimal(params.size).multiply(new BigDecimal(10**9))
     profile = params.base_profile_name
-    number_of_reads = total_size * abundance.toFloat() / read_length_ch.toFloat()
-    number_of_reads = number_of_reads.round(0).toLong()
+    coverage = total_size.multiply(new BigDecimal(abundance.toString())).divide(new BigDecimal(genome_size.toString()), java.math.MathContext.DECIMAL64)
+    coverage = coverage.stripTrailingZeros()
     // nanosim seed cannot be > 2**32 -1
     Long used_seed = (seed as Long) % 2**32 - 1
 
@@ -71,13 +71,13 @@ process simulate_reads_fasta_nanosim3 {
     log = log.concat("  abundance: ").concat(abundance)
     log = log.concat("    seed: ").concat(seed)
     log = log.concat("    used_seed: ").concat(Long.toString(used_seed))
-    log = log.concat("    number_of_reads: ").concat(Integer.toString(number_of_reads))
+    log = log.concat("    coverage: ").concat(coverage.toPlainString())
     log = log.concat("    profile: ").concat(profile)
     print(log)
     **/
 
     """
-    simulator.py genome -n ${number_of_reads} -rg ${fasta_file} -o sample${sample_id}_${genome_id} -c ${profile} --seed ${used_seed} -dna_type linear
+    simulator.py genome -x ${coverage} -rg ${fasta_file} -o sample${sample_id}_${genome_id} -c ${profile} --seed ${used_seed} -dna_type linear
     """
 }
 
@@ -94,7 +94,7 @@ process simulate_reads_fastq_nanosim3 {
     conda 'conda-forge::scikit-learn=0.23.2 conda-forge::numpy=1.23.5 bioconda::nanosim=3.2'
 	
     input:
-    tuple val(genome_id), val(sample_id), path(fasta_file), val(abundance), val (seed)
+    tuple val(genome_id), val(sample_id), path(fasta_file), val(abundance), val (seed), val(genome_size)
     val(read_length_ch)
     
     output:
@@ -104,8 +104,8 @@ process simulate_reads_fastq_nanosim3 {
     script:
     total_size = new BigDecimal(params.size).multiply(new BigDecimal(10**9))
     profile = params.base_profile_name
-    number_of_reads = total_size * abundance.toFloat() / read_length_ch.toFloat()
-    number_of_reads = number_of_reads.round(0).toLong()
+    coverage = total_size.multiply(new BigDecimal(abundance.toString())).divide(new BigDecimal(genome_size.toString()), java.math.MathContext.DECIMAL64)
+    coverage = coverage.stripTrailingZeros()
     // nanosim seed cannot be > 2**32 -1
     Long used_seed = (seed as Long) % 2**32 - 1
 
@@ -118,12 +118,12 @@ process simulate_reads_fastq_nanosim3 {
     echo "seed: ${seed}" >> debug_inputs.txt
     echo "used_seed: ${used_seed}" >> debug_inputs.txt
     echo "total_size: ${total_size}" >> debug_inputs.txt
-    echo "number_of_reads: ${number_of_reads}" >> debug_inputs.txt
+    echo "coverage: ${coverage}" >> debug_inputs.txt
     echo "profile: ${profile}" >> debug_inputs.txt
     **/
 
     """
-    simulator.py genome -n ${number_of_reads} -rg ${fasta_file} -o sample${sample_id}_${genome_id} -c ${profile} --seed ${used_seed} -dna_type linear --fastq
+    simulator.py genome -x ${coverage} -rg ${fasta_file} -o sample${sample_id}_${genome_id} -c ${profile} --seed ${used_seed} -dna_type linear --fastq
     mkdir --parents ${params.outdir}/sample_${sample_id}/reads/fastq/
     for file in *_aligned_reads.fastq; do gzip -k "\$file"; done
     cp *_aligned_reads.fastq.gz ${params.outdir}/sample_${sample_id}/reads/fastq/

--- a/pipelines/metagenomic/sample_wise_simulation.nf
+++ b/pipelines/metagenomic/sample_wise_simulation.nf
@@ -48,12 +48,14 @@ workflow sample_wise_simulation {
 
         // for read simulator nanosim, the abundance has to be normalised with the size in number of bases
         if(params.type.equals("nanosim3") or params.type.equals("wgsim")) {
-            
+
 
             // combining of the channels results in new map: key = genome_id, first value = path to genome, second value = distribution, third value = sample_id
             genome_location_distribution_ch = genome_location_ch.combine(distribution_file_ch, by: 0)
 
-            distribution_file_ch = normalise_abundance_to_size(count_bases(genome_location_distribution_ch))
+            counted_bases_ch = count_bases(genome_location_distribution_ch)
+            distribution_file_ch = normalise_abundance_to_size(counted_bases_ch)
+            genome_size_ch = counted_bases_ch.map { tuple(it[0], it[2], it[3].toString().trim()) }
 
         }
 
@@ -90,7 +92,8 @@ workflow sample_wise_simulation {
         } else if(params.type.equals("nanosim3")) {
 
             // simulate the reads with nanosim3
-            read_simulator_nanosim3(location_distribution_seed_ch, read_length_ch)
+            location_distribution_seed_size_ch = location_distribution_seed_ch.combine(genome_size_ch, by:[0,1])
+            read_simulator_nanosim3(location_distribution_seed_size_ch, read_length_ch)
             bam_files_channel = read_simulator_nanosim3.out[0]
             reads_ch = read_simulator_nanosim3.out[1]
 

--- a/pipelines/metatranscriptomic/read_simulators/read_simulator_nansoim3.nf
+++ b/pipelines/metatranscriptomic/read_simulators/read_simulator_nansoim3.nf
@@ -45,7 +45,7 @@ process simulate_reads_nanosim3 {
     //publishDir "${params.outdir}/sample_${sample_id}/reads/fastq/", pattern: "*_aligned_reads.fastq.gz", mode: 'copy'
 
     input:
-    tuple val(genome_id), val(sample_id), path(fasta_distribution_file), val(abundance), path(fasta_file), path(gff_file), val(seed), path(db)
+    tuple val(genome_id), val(sample_id), path(fasta_distribution_file), val(abundance), path(fasta_file), path(gff_file), val(seed), path(db), val(genome_size)
     val(read_length_ch)
 
     
@@ -60,8 +60,8 @@ process simulate_reads_nanosim3 {
     size = params.size
     read_length = read_length_ch
     basecaller = params.basecaller
-    number_of_reads = (size*(10**9)) * abundance.toFloat() / read_length_ch.toFloat()
-    number_of_reads = number_of_reads.round(0).toInteger()
+    coverage = new BigDecimal(size.toString()).multiply(new BigDecimal(10**9)).multiply(new BigDecimal(abundance.toString())).divide(new BigDecimal(genome_size.toString()), java.math.MathContext.DECIMAL64)
+    coverage = coverage.stripTrailingZeros()
     // nanosim seed cannot be > 2**32 -1
     //Long seed = 632741178
     //Long used_seed = seed % 2**32 - 1
@@ -77,7 +77,7 @@ process simulate_reads_nanosim3 {
     log = log.concat("  abundance: ").concat(abundance)
     log = log.concat("    seed: ").concat(Long.toString(seed))
     log = log.concat("    used_seed: ").concat(Long.toString(used_seed))
-    log = log.concat("    number_of_reads: ").concat(Integer.toString(number_of_reads))
+    log = log.concat("    coverage: ").concat(coverage.toPlainString())
     log = log.concat("    profile: ").concat(profile)
     print(log)
     **/
@@ -93,11 +93,9 @@ process simulate_reads_nanosim3 {
         --child_feature_type ${child_feature_type} \
         --fasta_distribution_file ${fasta_distribution_file}
 
-    total_read_count=\$(cat total_read_count.txt)
-
     # gffread -F -w transcriptome.fa -g ${fasta_file} sample${sample_id}_${genome_id}.gff3
 
-    simulator.py transcriptome -rt sample_${sample_id}_${genome_id}_transcriptome.fa -c ${profile} -e ${sample_id}_${genome_id}_expression_profile.tsv -n \$total_read_count --no_model_ir -b ${basecaller} --fastq -r cDNA_1D --seed ${used_seed} -o tmp_sample${sample_id}_${genome_id}
+    simulator.py transcriptome -rt sample_${sample_id}_${genome_id}_transcriptome.fa -c ${profile} -e ${sample_id}_${genome_id}_expression_profile.tsv -x ${coverage} --no_model_ir -b ${basecaller} --fastq -r cDNA_1D --seed ${used_seed} -o tmp_sample${sample_id}_${genome_id}
 
     # gzip -k sample${sample_id}_${genome_id}_aligned_reads.fastq
     # gzip -k *_aligned_reads.fastq

--- a/pipelines/metatranscriptomic/sample_wise_simulation.nf
+++ b/pipelines/metatranscriptomic/sample_wise_simulation.nf
@@ -59,6 +59,8 @@ workflow sample_wise_simulation {
         // normalize the distributions and read the results from the generated file
         normalised_distribution_ch = normalise_abundance_meta_t(distribution_file_ch.map { a -> tuple(a[1], tuple (a[0], a[2])) }.groupTuple())
             .map { file -> tuple(file.baseName.split('_')[2], file) }.splitCsv(sep:'\t').map { a -> tuple(a[1][0], a[1][1],a[0]) }.filter { it[1] != '0.0' }
+        counted_bases_ch = count_bases(genome_location_ch.combine(normalised_distribution_ch, by: 0).map { a -> tuple(a[0], a[1], a[3], a[2]) })
+        genome_size_ch = counted_bases_ch.map { tuple(it[0], it[2], it[3].toString().trim()) }
 
         // calculate gene expression
         final_gene_distr_ch = get_final_gene_distr(gene_distribution_file_ch.join(normalised_distribution_ch, by: [0,2]))
@@ -80,7 +82,8 @@ workflow sample_wise_simulation {
         } else if(params.type.equals("nanosim3")) {
 
             // simulate the reads with nanosim3
-            read_simulator_nanosim3(location_distribution_seed_ch, read_length_ch)
+            location_distribution_seed_size_ch = location_distribution_seed_ch.combine(genome_size_ch, by:[0,1])
+            read_simulator_nanosim3(location_distribution_seed_size_ch, read_length_ch)
 
             bam_files_channel = read_simulator_nanosim3.out[0]
             reads_ch = read_simulator_nanosim3.out[1]


### PR DESCRIPTION
## Summary
- calculate genome sizes and propagate them so NanoSim metagenomic simulations can request coverage instead of fixed read counts
- update both fasta and fastq NanoSim3 metagenomic processes to pass coverage derived from normalized abundances and total bases
- add genome-size tracking to the metatranscriptomic NanoSim3 workflow and use coverage when simulating transcriptome reads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303bc46900832ab0e642f8baac34e0)