### PR TITLE
Harden from_profile mode genome selection with new genomes, config loading, and output staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ __pycache__/
 *.py[cod]
 *.swp
 
+# Configs
+configs/
+camisim.cfg
+metax_bench_data.config
+
 # C extensions
 *.so
 

--- a/convert_config.py
+++ b/convert_config.py
@@ -76,6 +76,13 @@ def convert_to_nextflow_config(input_file, output_file):
                             nf_config.write(f"  {'verbose'} = false\n")
                     elif (key == 'distribution_file_paths'):
                         nf_config.write(f"  distribution_files = \"{value}\"\n")
+                    elif (key == 'prioritize_additional_genomes' or key == 'no_replace' or key == 'fill_up'):
+                        if(value == 'True'):
+                            nf_config.write(f"  {key} = true\n")
+                        else:
+                            nf_config.write(f"  {key} = false\n")
+                    elif (key == 'additional_references' or key == 'additional_genomes_quality_file' or key == 'reference_genomes' or key == 'biom_profile' or key == 'max_rank'):
+                        nf_config.write(f"  {key} = \"{value}\"\n")
                     else:
                         nf_config.write(f"  {key} = {value}\n")
 
@@ -84,6 +91,11 @@ def convert_to_nextflow_config(input_file, output_file):
         nf_config.write("  no_replace = true\n")
         nf_config.write("  no_replace = false\n")
         nf_config.write("  additional_references=\"\"\n")
+        nf_config.write("  prioritize_additional_genomes = false\n")
+        nf_config.write("  additional_genomes_quality_file=\"\"\n")
+        nf_config.write("  additional_genomes_max_contamination = 5\n")
+        nf_config.write("  additional_genomes_min_completeness = 95\n")
+        nf_config.write("  additional_genomes_max_num_contigs = 200\n")
         nf_config.write("  conda.enabled = true\n")
         nf_config.write("  conda.useMamba = true\n")
         nf_config.write("  conda.cacheDir=\"/home/jfunk/conda_cache\"\n")

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,9 +5,38 @@ params {
     config = ""
 }
 
+def resolveExternalConfigPath(rawPath) {
+    def trimmedPath = rawPath?.toString()?.trim()
+    if (!trimmedPath) {
+        return null
+    }
+
+    def providedFile = new File(trimmedPath)
+    if (providedFile.isAbsolute()) {
+        if (providedFile.exists()) {
+            return providedFile.canonicalPath
+        }
+    } else {
+        def launchDirFile = new File(System.getProperty('user.dir'), trimmedPath)
+        if (launchDirFile.exists()) {
+            return launchDirFile.canonicalPath
+        }
+
+        def projectDirFile = new File(projectDir.toString(), trimmedPath)
+        if (projectDirFile.exists()) {
+            return projectDirFile.canonicalPath
+        }
+    }
+
+    throw new IllegalArgumentException(
+        "External config file not found: '${trimmedPath}'. Checked the provided path, " +
+        "launch directory '${System.getProperty('user.dir')}', and project directory '${projectDir}'."
+    )
+}
+
 if (params.config && params.config.toString().trim()) {
 
-    includeConfig params.config
+    includeConfig resolveExternalConfigPath(params.config)
 
 } else if (params.pipeline == "metagenomic") {
 

--- a/pipelines/metagenomic/config/distribution.config
+++ b/pipelines/metagenomic/config/distribution.config
@@ -29,7 +29,7 @@ params {
     gauss_sigma = 1
 
     // Show the used distribution of genomes before simulating.
-    verbose = "False"
+    verbose = false
 
     // Total number of simulated genomes
     // Difference between genomes_total and genomes_real are simulated by sgEvolver

--- a/pipelines/metagenomic/config/metagenomic.config
+++ b/pipelines/metagenomic/config/metagenomic.config
@@ -57,7 +57,8 @@ params {
 
     // Maximum number of strains drawn from genomes belonging to a single OTU
     // OTU is taken from the metadata file
-    // If the simulation is executed from profile (see parameter biom_profile): max strains need to be greater or equal to 2
+    // In profile mode this is validated together with min_strains_per_otu.
+    // If max_strains_per_otu = 1, exactly one genome is drawn per OTU.
     max_strains_per_otu=2
 
     // Minimum number of strains drawn from genomes belonging to a single OTU

--- a/pipelines/metagenomic/config/profile.config
+++ b/pipelines/metagenomic/config/profile.config
@@ -13,6 +13,21 @@ params {
     // is optional
     additional_references=""
 
+    // If true, high-quality additional genomes are selected before public reference genomes.
+    // If false, public references and high-quality additional genomes are sampled together.
+    prioritize_additional_genomes = false
+
+    // TSV describing quality of genomes from additional_references.
+    // Required columns: genome_path, completeness, contamination, num_contigs.
+    // Required when additional_references is set.
+    additional_genomes_quality_file=""
+
+    // Quality thresholds for genomes from additional_references.
+    // Lower-quality additional genomes are only used as a last resort after the preferred pools are exhausted.
+    additional_genomes_max_contamination = 5
+    additional_genomes_min_completeness = 95
+    additional_genomes_max_num_contigs = 200
+
     // Highest taxonomic rank to draw genomes from. Note: If the rank of an OTU is higher than max_rank and
     // fill_up = true, a random genome will be drawn for the OTU
     max_rank = "family"

--- a/pipelines/metagenomic/config/profile.config
+++ b/pipelines/metagenomic/config/profile.config
@@ -9,8 +9,12 @@ params {
     // If no genomes are found for certain OTUs, fill up with previously unused genomes
     fill_up = false
 
-    // File containing additional reference genomes, mapped to OTUs from the input profile
-    // is optional
+    // Optional file containing additional reference genomes, mapped to taxa from the input profile.
+    // Accepted columns are either:
+    // ncbi_taxid <tab> scientific_name <tab> genome_path
+    // or:
+    // ncbi_taxid <tab> scientific_name <tab> genome_path <tab> novelty_category
+    // If novelty_category is omitted, it defaults to known_strain.
     additional_references=""
 
     // If true, high-quality additional genomes are selected before public reference genomes.
@@ -25,7 +29,7 @@ params {
     // Quality thresholds for genomes from additional_references.
     // Lower-quality additional genomes are only used as a last resort after the preferred pools are exhausted.
     additional_genomes_max_contamination = 5
-    additional_genomes_min_completeness = 95
+    additional_genomes_min_completeness = 90
     additional_genomes_max_num_contigs = 200
 
     // Highest taxonomic rank to draw genomes from. Note: If the rank of an OTU is higher than max_rank and

--- a/pipelines/metagenomic/from_profile.nf
+++ b/pipelines/metagenomic/from_profile.nf
@@ -12,12 +12,24 @@ shared_scripts_dir = "${projectDir}/pipelines/shared/scripts"
 workflow metagenomesimulation_from_profile {
 
     main:
+
+        reference_genomes = params.containsKey('reference_genomes') ? params.reference_genomes : "${projectDir}/tools/assembly_summary_complete_genomes.txt"
+        min_strains_per_otu = params.containsKey('min_strains_per_otu') ? params.min_strains_per_otu : 1
+        max_strains_per_otu = params.containsKey('max_strains_per_otu') ? params.max_strains_per_otu : 2
+        no_replace = params.containsKey('no_replace') ? params.no_replace : true
+        fill_up = params.containsKey('fill_up') ? params.fill_up : false
+        max_rank = params.containsKey('max_rank') ? params.max_rank : "family"
+        prioritize_additional_genomes = params.containsKey('prioritize_additional_genomes') ? params.prioritize_additional_genomes : false
+        additional_genomes_quality_file = params.containsKey('additional_genomes_quality_file') ? params.additional_genomes_quality_file : ""
+        additional_genomes_max_contamination = params.containsKey('additional_genomes_max_contamination') ? params.additional_genomes_max_contamination : 5
+        additional_genomes_min_completeness = params.containsKey('additional_genomes_min_completeness') ? params.additional_genomes_min_completeness : 95
+        additional_genomes_max_num_contigs = params.containsKey('additional_genomes_max_num_contigs') ? params.additional_genomes_max_num_contigs : 200
         
-        get_genomes(params.biom_profile, params.number_of_samples, params.reference_genomes, params.seed, params.gauss_mu, params.gauss_sigma, 
-            params.min_strains_per_otu, params.max_strains_per_otu, params.no_replace, params.fill_up,
-            params.ncbi_taxdump_file, params.max_rank, params.prioritize_additional_genomes,
-            params.additional_genomes_quality_file, params.additional_genomes_max_contamination,
-            params.additional_genomes_min_completeness, params.additional_genomes_max_num_contigs)
+        get_genomes(params.biom_profile, params.number_of_samples, reference_genomes, params.seed, params.gauss_mu, params.gauss_sigma,
+            min_strains_per_otu, max_strains_per_otu, no_replace, fill_up,
+            params.ncbi_taxdump_file, max_rank, prioritize_additional_genomes,
+            additional_genomes_quality_file, additional_genomes_max_contamination,
+            additional_genomes_min_completeness, additional_genomes_max_num_contigs)
 
         loc_ch = get_genomes.out[0]
         abundance_ch = get_genomes.out[1].flatten()
@@ -72,7 +84,7 @@ process get_genomes {
     additional_references = "None"
     additional_genomes_quality = "None"
 
-    if(!params.additional_references.isEmpty()) {
+    if(params.containsKey('additional_references') && !params.additional_references.isEmpty()) {
         additional_references = params.additional_references
     }
 
@@ -83,9 +95,12 @@ process get_genomes {
     """
     mkdir --parents ${params.outdir}/source_genomes/
     mkdir --parents ${params.outdir}/internal/
+    mkdir --parents ${params.outdir}/distributions/
 
     python ${scripts_dir}/get_genomes.py "${biom_profile}" ${number_of_samples} "${reference_genomes}" ${seed} ${mu} ${sigma} ${min_strains} ${max_strains} False ${no_replace} ${fill_up} "${scripts_dir}/split_fasta.pl" "${params.outdir}/source_genomes/" "${additional_references}" "${additional_genomes_quality}" "${ncbi_taxdump_file}" "${max_rank}" ${prioritize_additional_genomes} ${additional_genomes_max_contamination} ${additional_genomes_min_completeness} ${additional_genomes_max_num_contigs}
     cp metadata.tsv ${params.outdir}/internal/metadata.tsv
     cp genome_to_id.tsv ${params.outdir}/internal/genome_to_id.tsv
+    cp genome_to_id.tsv ${params.outdir}/internal/genome_locations.tsv
+    cp abundance_*.tsv ${params.outdir}/distributions/
     """
 }

--- a/pipelines/metagenomic/from_profile.nf
+++ b/pipelines/metagenomic/from_profile.nf
@@ -14,7 +14,10 @@ workflow metagenomesimulation_from_profile {
     main:
         
         get_genomes(params.biom_profile, params.number_of_samples, params.reference_genomes, params.seed, params.gauss_mu, params.gauss_sigma, 
-            params.min_strains_per_otu, params.max_strains_per_otu, params.no_replace, params.fill_up, params.ncbi_taxdump_file, params.max_rank)
+            params.min_strains_per_otu, params.max_strains_per_otu, params.no_replace, params.fill_up,
+            params.ncbi_taxdump_file, params.max_rank, params.prioritize_additional_genomes,
+            params.additional_genomes_quality_file, params.additional_genomes_max_contamination,
+            params.additional_genomes_min_completeness, params.additional_genomes_max_num_contigs)
 
         loc_ch = get_genomes.out[0]
         abundance_ch = get_genomes.out[1].flatten()
@@ -53,6 +56,11 @@ process get_genomes {
     val(fill_up)
     val(ncbi_taxdump_file)
     val(max_rank)
+    val(prioritize_additional_genomes)
+    val(additional_genomes_quality_file)
+    val(additional_genomes_max_contamination)
+    val(additional_genomes_min_completeness)
+    val(additional_genomes_max_num_contigs)
 
     output:
     path "genome_to_id.tsv"
@@ -62,16 +70,21 @@ process get_genomes {
     script:
 
     additional_references = "None"
+    additional_genomes_quality = "None"
 
     if(!params.additional_references.isEmpty()) {
         additional_references = params.additional_references
+    }
+
+    if(!additional_genomes_quality_file.isEmpty()) {
+        additional_genomes_quality = additional_genomes_quality_file
     }
 
     """
     mkdir --parents ${params.outdir}/source_genomes/
     mkdir --parents ${params.outdir}/internal/
 
-    python ${scripts_dir}/get_genomes.py ${biom_profile} ${number_of_samples} ${reference_genomes} ${seed} ${mu} ${sigma} ${min_strains} ${max_strains} False ${no_replace} ${fill_up} ${scripts_dir}/split_fasta.pl ${params.outdir}/source_genomes/ ${additional_references} ${ncbi_taxdump_file} "${max_rank}"
+    python ${scripts_dir}/get_genomes.py "${biom_profile}" ${number_of_samples} "${reference_genomes}" ${seed} ${mu} ${sigma} ${min_strains} ${max_strains} False ${no_replace} ${fill_up} "${scripts_dir}/split_fasta.pl" "${params.outdir}/source_genomes/" "${additional_references}" "${additional_genomes_quality}" "${ncbi_taxdump_file}" "${max_rank}" ${prioritize_additional_genomes} ${additional_genomes_max_contamination} ${additional_genomes_min_completeness} ${additional_genomes_max_num_contigs}
     cp metadata.tsv ${params.outdir}/internal/metadata.tsv
     cp genome_to_id.tsv ${params.outdir}/internal/genome_to_id.tsv
     """

--- a/pipelines/metagenomic/metagenomic.nf
+++ b/pipelines/metagenomic/metagenomic.nf
@@ -175,7 +175,7 @@ workflow metagenomic {
         }
 
     // make all sequences from input genomes (also strain simulated ones) unique and move them to an output location
-    genome_location_file_ch = cleanup_and_filter_sequences(genome_location_file_ch, genome_location_ch.map { it[1] }.collect())
+    genome_location_file_ch = cleanup_and_filter_sequences(genome_location_file_ch, genome_location_ch.collect(flat: false))
     
     // this channel holds the genome location map (key = genome_id, value = absolute path to genome)
     genome_location_ch = genome_location_file_ch
@@ -547,19 +547,30 @@ process cleanup_and_filter_sequences {
 
     input:
     path genome_id_to_file_path
-    path genomes
+    val genome_entries
 
     output:
-    path genome_id_to_file_path
+    path "internal_*"
 
     script:
+    normalized_genome_entries = genome_entries.collect { entry ->
+        if (entry instanceof List || entry instanceof Object[]) {
+            if (entry.size() >= 2) {
+                return [entry[0], entry[1]]
+            }
+        }
+        throw new IllegalArgumentException("cleanup_and_filter_sequences expected [genome_id, path] entries but received: ${entry}")
+    }
+    absolute_genome_id_to_file_path = normalized_genome_entries.collect { "${it[0]}\t${it[1]}" }.join('\n')
     """
     mkdir --parents ${params.outdir}/source_genomes/
     mkdir --parents ${params.outdir}/internal/
 
-    touch internal_${genome_id_to_file_path}
+cat > absolute_${genome_id_to_file_path} <<'EOF'
+${absolute_genome_id_to_file_path}
+EOF
 
-    python ${scripts_dir}/clean_up_sequences.py ${genome_id_to_file_path} ${params.outdir}/source_genomes/ internal_${genome_id_to_file_path}
+    python ${scripts_dir}/clean_up_sequences.py absolute_${genome_id_to_file_path} ${params.outdir}/source_genomes/ internal_${genome_id_to_file_path}
 
     cp ./out_genomes/* ${params.outdir}/source_genomes/
     cp internal_${genome_id_to_file_path} ${params.outdir}/internal/genome_locations.tsv

--- a/pipelines/metagenomic/scripts/clean_up_sequences.py
+++ b/pipelines/metagenomic/scripts/clean_up_sequences.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 from Bio import SeqIO
 
 def get_new_name(name, set_of_sequence_names):
@@ -81,6 +82,23 @@ def parse_tsv_to_dict(file):
             result_dict[key] = value
     return result_dict
 
+
+def get_unique_output_file_path(file_path_input, directory_output, genome_id, used_output_file_names):
+    file_name = os.path.basename(file_path_input)
+    stem, extension = os.path.splitext(file_name)
+    candidate = file_name
+    safe_genome_id = re.sub(r'[^A-Za-z0-9._-]+', '_', genome_id)
+
+    if candidate in used_output_file_names:
+        candidate = "{}__{}{}".format(safe_genome_id, stem, extension)
+        index = 1
+        while candidate in used_output_file_names:
+            candidate = "{}__{}_{}{}".format(safe_genome_id, stem, index, extension)
+            index += 1
+
+    used_output_file_names.add(candidate)
+    return os.path.join(directory_output, candidate)
+
 def write_genome_id_to_path_map(genome_id_to_path_map, file_path_output, outdir):
     """
     Write mapping of genome id to genome file path to a file.
@@ -118,6 +136,7 @@ if __name__ == "__main__":
     set_of_sequence_names = set()
     directory_output = "./out_genomes/"
     genome_id_to_path_map = dict()
+    used_output_file_names = set()
 
     # Create the output directory if it does not exist
     os.makedirs(directory_output, exist_ok=True)
@@ -128,12 +147,12 @@ if __name__ == "__main__":
     with open(file_path_sequence_map, 'w') as stream_map:
 
         for genome_id, genome_file_path in genome_id_to_file_path.items():
-            file_name = os.path.basename(genome_file_path)
-
-            new_genome_file_path = os.path.join(directory_output, file_name)
+            new_genome_file_path = get_unique_output_file_path(
+                genome_file_path, directory_output, genome_id, used_output_file_names
+            )
 
             move_genome_file(
-                file_name, new_genome_file_path, stream_map, genome_id, sequence_min_length, set_of_sequence_names)
+                genome_file_path, new_genome_file_path, stream_map, genome_id, sequence_min_length, set_of_sequence_names)
             genome_id_to_path_map[genome_id] = new_genome_file_path
         
             

--- a/pipelines/metagenomic/scripts/get_genomes.py
+++ b/pipelines/metagenomic/scripts/get_genomes.py
@@ -4,9 +4,14 @@ import os
 import gzip
 import urllib.request
 import shutil
+import re
 from numpy import random as np_rand
-from ete4 import NCBITaxa
 import sqlite3
+
+try:
+    from ete4 import NCBITaxa
+except ModuleNotFoundError:
+    from ete3 import NCBITaxa
 
 number_of_samples = 0
 LEGACY_RANKS = ['species', 'genus', 'family', 'order', 'class', 'phylum', 'superkingdom']
@@ -53,6 +58,100 @@ def normalize_genome_key(genome_path):
     if "://" in genome_path:
         return genome_path.rstrip("/")
     return os.path.normpath(genome_path)
+
+
+def sanitize_filename_component(value):
+    value = re.sub(r'[^A-Za-z0-9._-]+', '_', value.strip())
+    value = value.strip('._')
+    return value or "genome"
+
+
+def strip_known_fasta_extensions(file_name):
+    file_name = file_name.strip()
+    for extension in ['.fasta.gz', '.fa.gz', '.fna.gz', '.fas.gz', '.gz', '.fasta', '.fa', '.fna', '.fas']:
+        if file_name.lower().endswith(extension):
+            return file_name[:-len(extension)]
+    return os.path.splitext(file_name)[0]
+
+
+def build_output_genome_path(output_dir, genome_label, source_path, used_output_names):
+    label_component = sanitize_filename_component(genome_label)
+    source_name_component = sanitize_filename_component(
+        strip_known_fasta_extensions(os.path.basename(source_path.rstrip("/")))
+    )
+
+    if source_name_component.lower() in label_component.lower():
+        base_name = label_component
+    else:
+        base_name = "{}__{}".format(label_component, source_name_component)
+
+    file_name = base_name + ".fa"
+    suffix = 1
+    while file_name in used_output_names:
+        file_name = "{}_{}.fa".format(base_name, suffix)
+        suffix += 1
+    used_output_names.add(file_name)
+    return os.path.join(output_dir, file_name)
+
+
+def get_table_columns(header_parts, aliases):
+    columns = {}
+    lowered = [part.strip().lower() for part in header_parts]
+    for column_name, options in aliases.items():
+        for option in options:
+            if option in lowered:
+                columns[column_name] = lowered.index(option)
+                break
+    return columns
+
+
+def iter_tabular_rows(file_path, aliases, default_indices, required_columns, optional_defaults = None):
+    optional_defaults = optional_defaults or {}
+
+    def build_row(parts, column_map, line):
+        row = {}
+        for column in required_columns:
+            index = column_map[column]
+            if len(parts) <= index:
+                raise ValueError("Malformed row in '{}': {}".format(file_path, line.rstrip('\n')))
+            row[column] = parts[index].strip()
+
+        for column, default_value in optional_defaults.items():
+            index = column_map.get(column)
+            if index is not None and len(parts) > index:
+                row[column] = parts[index].strip()
+            else:
+                row[column] = default_value
+        return row
+
+    with open(file_path, 'r') as stream:
+        first_line = stream.readline()
+        if not first_line:
+            return
+
+        first_parts = first_line.rstrip('\n').split('\t')
+        header_columns = get_table_columns(first_parts, aliases)
+        if all(column in header_columns for column in required_columns):
+            column_map = {column: header_columns[column] for column in required_columns}
+            for column in optional_defaults:
+                if column in header_columns:
+                    column_map[column] = header_columns[column]
+        else:
+            column_map = {column: default_indices[column] for column in required_columns}
+            required_max_index = max(column_map.values())
+            if len(first_parts) <= required_max_index:
+                raise ValueError("Malformed row in '{}': {}".format(file_path, first_line.rstrip('\n')))
+            for column in optional_defaults:
+                index = default_indices.get(column)
+                if index is not None and len(first_parts) > index:
+                    column_map[column] = index
+            yield build_row(first_parts, column_map, first_line)
+
+        for line in stream:
+            if not line.strip():
+                continue
+            parts = line.rstrip('\n').split('\t')
+            yield build_row(parts, column_map, line)
 
 
 def get_required_quality_column(columns, aliases):
@@ -107,7 +206,9 @@ def meets_additional_quality_requirements(quality_entry, max_contamination, min_
 """
 Reads list of available genomes in the (tsv) format:
 NCBI_ID Scientific_Name ftp_path
-Additional files might be provided with:
+Additional files might be provided with either:
+NCBI_ID Scientific_Name genome_path
+or:
 NCBI_ID Scientific_Name genome_path novelty_category
 were path might either be online or offline/local
 """
@@ -116,59 +217,120 @@ def read_genomes_list(genomes_path, additional_file = None, additional_quality_f
     genomes_map = {}
     total_genomes = 0
     additional_quality = {}
+    reference_aliases = {
+        "taxid": ["ncbi_id", "ncbi_taxid", "taxid"],
+        "name": ["scientific_name", "sci_name", "unique_taxon_name", "name"],
+        "path": ["ftp_path", "genome_path", "path", "ftp"]
+    }
+    additional_aliases = {
+        "taxid": ["ncbi_id", "ncbi_taxid", "taxid"],
+        "name": ["scientific_name", "sci_name", "unique_taxon_name", "name"],
+        "path": ["genome_path", "path", "ftp_path", "ftp"],
+        "novelty": ["novelty_category", "novelty"]
+    }
+
     if additional_file is not None:
         if additional_quality_file is None:
             raise ValueError("Parameter additional_genomes_quality_file is required when additional_references is set")
         additional_quality = read_additional_genomes_quality(additional_quality_file)
-        with open(additional_file,'r') as add:
-            for line in add:
-                if not line.strip():
-                    continue
-                ncbi_id, sci_name, path, novelty = line.strip().split('\t')
-                path_key = normalize_genome_key(path)
-                if path_key not in additional_quality:
-                    raise ValueError("Missing quality entry for additional genome '%s' in '%s'" % (path, additional_quality_file))
-                quality_entry = additional_quality[path_key]
-                genome_record = {
-                    "path": path,
-                    "novelty": novelty,
-                    "source": "additional",
-                    "quality_pass": meets_additional_quality_requirements(
-                        quality_entry,
-                        max_contamination,
-                        min_completeness,
-                        max_num_contigs
-                    )
-                }
-                if ncbi_id in genomes_map:
-                    genomes_map[ncbi_id]["genomes"].append(genome_record)
-                else:
-                    genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]}
-                total_genomes += 1
-    with open(genomes_path,'r') as genomes:
-        for line in genomes:
-            if not line.strip():
-                continue
-            ncbi_id, sci_name, ftp = line.strip().split('\t')
-            http = ftp.replace("ftp://","http://") # not using ftp address but http (proxies)
+        for row in iter_tabular_rows(
+            additional_file,
+            additional_aliases,
+            {"taxid": 0, "name": 1, "path": 2, "novelty": 3},
+            ["taxid", "name", "path"],
+            {"novelty": "known_strain"}
+        ):
+            ncbi_id = row["taxid"]
+            sci_name = row["name"]
+            path = row["path"]
+            novelty = row["novelty"]
+            path_key = normalize_genome_key(path)
+            if path_key not in additional_quality:
+                raise ValueError("Missing quality entry for additional genome '%s' in '%s'" % (path, additional_quality_file))
+            quality_entry = additional_quality[path_key]
             genome_record = {
-                "path": http,
-                "novelty": 'known_strain',
-                "source": "reference",
-                "quality_pass": True
+                "path": path,
+                "novelty": novelty,
+                "source": "additional",
+                "label": sci_name,
+                "quality_pass": meets_additional_quality_requirements(
+                    quality_entry,
+                    max_contamination,
+                    min_completeness,
+                    max_num_contigs
+                )
             }
             if ncbi_id in genomes_map:
                 genomes_map[ncbi_id]["genomes"].append(genome_record)
             else:
-                genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]} # sci_name is always the same for same taxid (?)
+                genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]}
             total_genomes += 1
+    for row in iter_tabular_rows(
+        genomes_path,
+        reference_aliases,
+        {"taxid": 0, "name": 1, "path": 2},
+        ["taxid", "name", "path"]
+    ):
+        ncbi_id = row["taxid"]
+        sci_name = row["name"]
+        ftp = row["path"]
+        http = ftp.replace("ftp://","http://") # not using ftp address but http (proxies)
+        genome_record = {
+            "path": http,
+            "novelty": 'known_strain',
+            "source": "reference",
+            "label": sci_name,
+            "quality_pass": True
+        }
+        if ncbi_id in genomes_map:
+            genomes_map[ncbi_id]["genomes"].append(genome_record)
+        else:
+            genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]} # sci_name is always the same for same taxid (?)
+        total_genomes += 1
     return genomes_map, total_genomes
+
+
+def get_cached_rank(tax_id, ncbi, rank_cache):
+    if tax_id not in rank_cache:
+        rank_cache[tax_id] = ncbi.get_rank([tax_id]).get(tax_id)
+    return rank_cache[tax_id]
+
+
+def resolve_name_to_allowed_taxid(name, ncbi, name_taxid_cache, rank_cache):
+    if name in name_taxid_cache:
+        return name_taxid_cache[name]
+
+    candidate_names = [name]
+    fallback_name = name.split()[0]
+    if fallback_name and fallback_name != name:
+        candidate_names.append(fallback_name)
+
+    resolved_taxid = None
+    for candidate_name in candidate_names:
+        if candidate_name in name_taxid_cache:
+            resolved_taxid = name_taxid_cache[candidate_name]
+        else:
+            mapping = ncbi.get_name_translator([candidate_name])
+            if candidate_name in mapping:
+                taxid = mapping[candidate_name][0]
+                rank = get_cached_rank(taxid, ncbi, rank_cache)
+                resolved_taxid = taxid if rank in RANKS else None
+            else:
+                resolved_taxid = None
+            name_taxid_cache[candidate_name] = resolved_taxid
+
+        if resolved_taxid is not None:
+            break
+
+    name_taxid_cache[name] = resolved_taxid
+    return resolved_taxid
 
 """
 Given all available genomes, creates a map sorted by ranks of available genomes on that particular rank, ordered by their ncbi ids
 """
-def get_genomes_per_rank(genomes_map, ncbi):
+def get_genomes_per_rank(genomes_map, ncbi, rank_cache):
     per_rank_map = {}
+    genome_bucket_map = {}
     for rank in RANKS:
         per_rank_map[rank] = {}
     for genome in genomes_map:
@@ -177,28 +339,34 @@ def get_genomes_per_rank(genomes_map, ncbi):
             ranks_lin = ncbi.get_rank(lineage)
             genome_records = []
             for genome_record in genomes_map[genome]["genomes"]:
-                genome_records.append({
+                bucketed_genome_record = {
                     "path": genome_record["path"],
                     "genome_id": genome,
                     "novelty": genome_record["novelty"],
                     "source": genome_record["source"],
+                    "label": genome_record["label"],
                     "quality_pass": genome_record["quality_pass"]
-                })
+                }
+                genome_records.append(bucketed_genome_record)
+                genome_bucket_map[id(bucketed_genome_record)] = []
             for tax_id in lineage: # go over the lineage
                 try:
                     check_rank = ranks_lin[tax_id]
                 except KeyError:
                     continue
+                rank_cache[tax_id] = check_rank
                 if check_rank in per_rank_map: # if we are a legal rank
                     rank_map = per_rank_map[ranks_lin[tax_id]]
                     if tax_id not in rank_map: # tax id doesn't have a genome yet
                         rank_map[tax_id] = []
+                    bucket = rank_map[tax_id]
                     for genome_record in genome_records:
-                        rank_map[tax_id].append(genome_record)
+                        bucket.append(genome_record)
+                        genome_bucket_map[id(genome_record)].append(bucket)
         except ValueError as e:
 #           log.warning(e)
             print(e) # ToDo
-    return per_rank_map
+    return per_rank_map, genome_bucket_map
 
 """
 Sorts the otus in the profile by abundance
@@ -217,23 +385,18 @@ def sort_by_abundance(profile):
 Given a BIOM lineage, create a NCBI tax id lineage
 """
 def transform_lineage(lineage, ncbi):
+    return transform_lineage_with_cache(lineage, ncbi, {}, {})
+
+
+def transform_lineage_with_cache(lineage, ncbi, name_taxid_cache, rank_cache):
     new_lineage = []
     for member in lineage:
         name = member.split("__")[-1] # name is on the right hand side
         if len(name) == 0:
             continue
-        mapping = ncbi.get_name_translator([name])
-        if name in mapping:
-            taxid = mapping[name][0]
-            if ncbi.get_rank([taxid])[taxid] in RANKS:
-                new_lineage.append(taxid) # should contain only one element
-        else:
-            fallback_name = name.split()[0]
-            fallback_mapping = ncbi.get_name_translator([fallback_name])
-            if fallback_name in fallback_mapping:
-                taxid = fallback_mapping[fallback_name][0]
-                if ncbi.get_rank([taxid])[taxid] in RANKS:
-                    new_lineage.append(taxid) # retry if space in name destroys ID
+        taxid = resolve_name_to_allowed_taxid(name, ncbi, name_taxid_cache, rank_cache)
+        if taxid is not None:
+            new_lineage.append(taxid) # should contain only one element
     return new_lineage[::-1] # invert list, so lowest rank appears first (last in BIOM)
 
 
@@ -252,12 +415,41 @@ def truncated_geometric(p, l, u, max_tries=100000):
     )
 
 
+def validate_strain_bounds(min_strains, max_strains):
+    if min_strains < 1 or max_strains < 1:
+        raise ValueError(
+            f"Invalid strain bounds: min_strains={min_strains}, max_strains={max_strains}. "
+            "Both values must be at least 1."
+        )
+    if min_strains > max_strains:
+        raise ValueError(
+            f"Invalid strain bounds: min_strains={min_strains}, max_strains={max_strains}. "
+            "min_strains must be less than or equal to max_strains."
+        )
+
+
+def draw_num_strains(min_strains, max_strains):
+    validate_strain_bounds(min_strains, max_strains)
+
+    if min_strains == max_strains:
+        return min_strains
+
+    # The historical geometric draw becomes pathological for max_strains <= 2:
+    # with max=2 it can only return 1, and with max=1 it is invalid.
+    # Use a bounded uniform draw for these small ranges and preserve the
+    # previous geometric behaviour for larger ranges.
+    if max_strains <= 2:
+        return int(np_rand.randint(min_strains, max_strains + 1))
+
+    return truncated_geometric(2. / max_strains, min_strains, max_strains)
+
+
 def set_abundances(otu_genome_map, abundances, used_genomes, otu, tax_id, mu, sigma):
     log_normal_vals = np_rand.lognormal(mu, sigma, len(used_genomes))
     sum_log_normal = sum(log_normal_vals)
     for i, genome in enumerate(used_genomes):
         otu_id = otu + "." + str(i)
-        otu_genome_map[otu_id] = (tax_id, genome["genome_id"], genome["path"], genome["novelty"], [])  # taxid, genomeid, http path, novelty, abundances per sample
+        otu_genome_map[otu_id] = (tax_id, genome["genome_id"], genome["path"], genome["novelty"], genome["label"], [])  # taxid, genomeid, http path, novelty, label, abundances per sample
         relative_abundance = log_normal_vals[i] / sum_log_normal
         for abundance in abundances:  # calculate abundance per sample
             current_abundance = relative_abundance * abundance
@@ -286,14 +478,27 @@ def get_candidate_groups(available_genomes, prioritize_additional_genomes):
     return candidate_groups
 
 
-def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace, prioritize_additional_genomes):
-    rank = ncbi.get_rank([tax_id])[tax_id]
+def remove_genomes_from_rank_map(used_genomes, genome_bucket_map):
+    for genome in used_genomes:
+        bucket_refs = genome_bucket_map.pop(id(genome), None)
+        if not bucket_refs:
+            continue
+        for bucket in bucket_refs:
+            try:
+                bucket.remove(genome)
+            except ValueError:
+                continue
+
+
+def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace,
+                 prioritize_additional_genomes, rank_cache, genome_bucket_map):
+    rank = get_cached_rank(tax_id, ncbi, rank_cache)
     if RANKS.index(rank) > RANKS.index(max_rank):
         return []
     available_genomes = per_rank_map[rank].get(tax_id)
     if not available_genomes:
         return []
-    strains_to_draw = truncated_geometric(2. / max_strains, min_strains, max_strains)
+    strains_to_draw = draw_num_strains(min_strains, max_strains)
     used_genomes = []
     for candidate_group in get_candidate_groups(available_genomes, prioritize_additional_genomes):
         remaining = strains_to_draw - len(used_genomes)
@@ -302,11 +507,7 @@ def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi,
         used_genomes.extend(sample_genomes(candidate_group, remaining))
 
     if no_replace: # sampling without replacement:
-        for genome in used_genomes:
-            for new_rank in per_rank_map:
-                for taxid in per_rank_map[new_rank]:
-                    if genome in per_rank_map[new_rank][taxid]:
-                        per_rank_map[new_rank][taxid].remove(genome)
+        remove_genomes_from_rank_map(used_genomes, genome_bucket_map)
 
     return used_genomes
 
@@ -315,7 +516,8 @@ def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi,
 Given the OTU to lineage/abundances map and the genomes to lineage map, create map otu: taxid, genome, abundances
 """
 def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_strains, no_replace,
-                        max_genomes, max_rank, prioritize_additional_genomes, ncbi):
+                        max_genomes, max_rank, prioritize_additional_genomes, ncbi, rank_cache,
+                        genome_bucket_map):
     unmatched_otus = []
     matched_otus = set()
     otu_genome_map = {}
@@ -325,9 +527,10 @@ def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_s
     otu_to_lineage = {}
     otus_list = []
     max_lineage_len = 0
+    name_taxid_cache = {}
     for otu in sorted_otus:
         lin, _ = tax_profile[otu]
-        otu_to_lineage[otu] = transform_lineage(lin, ncbi)
+        otu_to_lineage[otu] = transform_lineage_with_cache(lin, ncbi, name_taxid_cache, rank_cache)
         if len(otu_to_lineage[otu]) == 0:
             unmatched_otus.append(otu)
             continue
@@ -346,8 +549,10 @@ def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_s
             except IndexError:
                 continue
 
-            used_genomes = pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace,
-                                        prioritize_additional_genomes)
+            used_genomes = pick_genomes(
+                tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace,
+                prioritize_additional_genomes, rank_cache, genome_bucket_map
+            )
             if not used_genomes:
                 continue
 
@@ -375,6 +580,7 @@ def fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile, d
                         "path": genome["path"],
                         "novelty": genome["novelty"],
                         "source": genome["source"],
+                        "label": genome["label"],
                         "quality_pass": genome["quality_pass"]
                     }
 
@@ -389,7 +595,7 @@ def fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile, d
     for i, genome in enumerate(ordered_genomes[:len(unmatched_otus)]):
         curr_otu = unmatched_otus[otu_indices[i]] #so we choose a random genome
         lineage, abundances = tax_profile[curr_otu]
-        otu_genome_map[curr_otu] = (genome["tax_id"], genome["genome_id"], genome["path"], genome["novelty"], abundances)
+        otu_genome_map[curr_otu] = (genome["tax_id"], genome["genome_id"], genome["path"], genome["novelty"], genome["label"], abundances)
 #        if debug:
 #            _log.warning("Filling up OTU %s (mapped tax id: %s) to genome with tax id %s" % (curr_otu, lin[0], tax_id))
     return otu_genome_map
@@ -405,16 +611,15 @@ def split_by_N(fasta_path, out_path, script):
 """
 Downloads the given genome and returns the out path
 """
-def download_genome(genome, out_path, script):
-    # genome_path = os.path.join(out_path,"genomes")
-    genome_path = out_path
-
-
+def download_genome(genome, output_path, script):
+    genome_path = os.path.dirname(output_path)
+    if genome_path and not os.path.exists(genome_path):
+        os.makedirs(genome_path)
     out_name = genome.rstrip().split('/')[-1]
     http_address = os.path.join(genome, out_name + "_genomic.fna.gz")
     opened = urllib.request.urlopen(http_address)
-    out = os.path.join(genome_path, out_name + ".fa")
-    tmp_out = os.path.join(genome_path, out_name + "tmp.fa")
+    out = output_path
+    tmp_out = output_path + ".tmp"
     out_gz = out + ".gz"
     with open(out_gz,'wb') as outF:
         outF.write(opened.read())
@@ -435,8 +640,6 @@ def write_config(otu_genome_map, no_samples, script, out_path_genomes):
     genome_to_id = os.path.join(out_path, "genome_to_id.tsv")
     #config.set('community0','id_to_genome_file', genome_to_id)
     metadata = os.path.join(out_path, "metadata.tsv")
-    with open(metadata,'w') as md:
-        md.write("genome_ID\tOTU\tNCBI_ID\tnovelty_category\n") # write header
     #config.set('community0','metadata',metadata)
     #no_samples = int(config.get("Main","number_of_samples"))
     abundances = [os.path.join(out_path,"abundance_%s.tsv" % i) for i in range(no_samples)]
@@ -447,35 +650,38 @@ def write_config(otu_genome_map, no_samples, script, out_path_genomes):
 
     if not os.path.exists(create_path):
         os.makedirs(create_path)
-    for otu in otu_genome_map:
-        taxid, genome_id, path, novelty, curr_abundances = otu_genome_map[otu]
-        counter = 0
-        while counter < 10:
-            try:
-                if path.startswith('http') or path.startswith('ftp'):
-                    genome_path = download_genome(path, out_path_genomes, script)
-                else:
-                    out_name = path.rstrip().split('/')[-1]
-                    genome_path = os.path.join(create_path, out_name)
-                    shutil.copy2(path, genome_path)
-                break
-            except Exception as e:
-                counter += 1
-                #log.error("Caught exception %s while moving/downloading genomes" % repr(e))
-                if counter >= 10:
-                    raise ValueError("Caught exception %s while moving/downloading genomes" % repr(e))
-        if counter == 10:
-#            log.error("Genome %s (from %s, path %s) could not be downloaded after 10 tries, check your connection settings" % (otu, genome_id, path))
-            raise ValueError("Genome %s (from %s, path %s) could not be downloaded after 10 tries, check your connection settings" % (otu, genome_id, path))
-        with open(genome_to_id,'a+') as gid:
-            gid.write("%s\t%s\n" % (otu, genome_path))
-        with open(metadata,'a+') as md:
-            md.write("%s\t%s\t%s\t%s\n" % (otu,taxid,genome_id,novelty))
-        i = 0
-        for abundance in abundances:
-            with open(abundance, 'a+') as ab:
-                ab.write("%s\t%s\n" % (otu,curr_abundances[i]))
-            i += 1
+    used_output_names = set()
+    abundance_streams = [open(abundance, 'w') for abundance in abundances]
+    try:
+        with open(genome_to_id, 'w') as gid, open(metadata,'w') as md:
+            md.write("genome_ID\tOTU\tNCBI_ID\tnovelty_category\n") # write header
+            for otu in otu_genome_map:
+                taxid, genome_id, path, novelty, genome_label, curr_abundances = otu_genome_map[otu]
+                target_genome_path = build_output_genome_path(create_path, genome_label, path, used_output_names)
+                counter = 0
+                while counter < 10:
+                    try:
+                        if path.startswith('http') or path.startswith('ftp'):
+                            genome_path = download_genome(path, target_genome_path, script)
+                        else:
+                            genome_path = target_genome_path
+                            shutil.copy2(path, genome_path)
+                        break
+                    except Exception as e:
+                        counter += 1
+                        #log.error("Caught exception %s while moving/downloading genomes" % repr(e))
+                        if counter >= 10:
+                            raise ValueError("Caught exception %s while moving/downloading genomes" % repr(e))
+                if counter == 10:
+    #            log.error("Genome %s (from %s, path %s) could not be downloaded after 10 tries, check your connection settings" % (otu, genome_id, path))
+                    raise ValueError("Genome %s (from %s, path %s) could not be downloaded after 10 tries, check your connection settings" % (otu, genome_id, path))
+                gid.write("%s\t%s\n" % (otu, genome_path))
+                md.write("%s\t%s\t%s\t%s\n" % (otu,taxid,genome_id,novelty))
+                for abundance_stream, abundance_value in zip(abundance_streams, curr_abundances):
+                    abundance_stream.write("%s\t%s\n" % (otu, abundance_value))
+    finally:
+        for abundance_stream in abundance_streams:
+            abundance_stream.close()
 
 
 def str2bool(x):
@@ -509,10 +715,13 @@ def main(biom_profile, no_samples, reference_genomes, seed, mu, sigma,
     if additional_genomes_quality_file == "None":
         additional_genomes_quality_file = None
 
+    validate_strain_bounds(min_strains, max_strains)
+
     np_rand.seed(seed)
 
     ncbi = NCBITaxa(taxdump_file=ncbi_taxdump_file)
     set_ranks(ncbi)
+    rank_cache = {}
 
     tax_profile = read_taxonomic_profile(biom_profile, no_samples)
     genomes_map, total_genomes = read_genomes_list(reference_genomes, additional_references,
@@ -520,11 +729,12 @@ def main(biom_profile, no_samples, reference_genomes, seed, mu, sigma,
                                                    additional_genomes_max_contamination,
                                                    additional_genomes_min_completeness,
                                                    additional_genomes_max_num_contigs)
-    per_rank_map = get_genomes_per_rank(genomes_map, ncbi)
+    per_rank_map, genome_bucket_map = get_genomes_per_rank(genomes_map, ncbi, rank_cache)
     otu_genome_map, unmatched_otus = map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma,
                                                          min_strains, max_strains, no_replace,
                                                          total_genomes, max_rank,
-                                                         prioritize_additional_genomes, ncbi)
+                                                         prioritize_additional_genomes, ncbi, rank_cache,
+                                                         genome_bucket_map)
 
     if fill_up and len(unmatched_otus) > 0:
         otu_genome_map = fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile,

--- a/pipelines/metagenomic/scripts/get_genomes.py
+++ b/pipelines/metagenomic/scripts/get_genomes.py
@@ -48,6 +48,62 @@ def read_taxonomic_profile(biom_profile, no_samples = None):
     return profile
 
 
+def normalize_genome_key(genome_path):
+    genome_path = genome_path.strip()
+    if "://" in genome_path:
+        return genome_path.rstrip("/")
+    return os.path.normpath(genome_path)
+
+
+def get_required_quality_column(columns, aliases):
+    for alias in aliases:
+        if alias in columns:
+            return columns[alias]
+    raise ValueError("Required column(s) missing from additional genome quality file: %s" % ", ".join(aliases))
+
+
+def read_additional_genomes_quality(quality_file):
+    quality_by_path = {}
+    with open(quality_file, 'r') as quality_stream:
+        header = quality_stream.readline().rstrip('\n').split('\t')
+        if not header or header == ['']:
+            raise ValueError("Additional genome quality file '%s' is empty" % quality_file)
+
+        columns = {column.strip().lower(): idx for idx, column in enumerate(header)}
+        idx_path = get_required_quality_column(columns, ['genome_path', 'path', 'genome'])
+        idx_completeness = get_required_quality_column(columns, ['completeness'])
+        idx_contamination = get_required_quality_column(columns, ['contamination'])
+        idx_num_contigs = get_required_quality_column(columns, ['num_contigs', 'contigs'])
+        max_idx = max(idx_path, idx_completeness, idx_contamination, idx_num_contigs)
+
+        for line in quality_stream:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            parts = line.split('\t')
+            if len(parts) <= max_idx:
+                raise ValueError("Malformed row in additional genome quality file '%s': %s" % (quality_file, line))
+
+            genome_key = normalize_genome_key(parts[idx_path])
+            if genome_key in quality_by_path:
+                raise ValueError("Duplicate quality entry for additional genome '%s'" % parts[idx_path])
+
+            quality_by_path[genome_key] = {
+                "completeness": float(parts[idx_completeness]),
+                "contamination": float(parts[idx_contamination]),
+                "num_contigs": int(float(parts[idx_num_contigs]))
+            }
+    return quality_by_path
+
+
+def meets_additional_quality_requirements(quality_entry, max_contamination, min_completeness, max_num_contigs):
+    return (
+        quality_entry["contamination"] <= max_contamination and
+        quality_entry["completeness"] >= min_completeness and
+        quality_entry["num_contigs"] <= max_num_contigs
+    )
+
+
 """
 Reads list of available genomes in the (tsv) format:
 NCBI_ID Scientific_Name ftp_path
@@ -55,26 +111,56 @@ Additional files might be provided with:
 NCBI_ID Scientific_Name genome_path novelty_category
 were path might either be online or offline/local
 """
-def read_genomes_list(genomes_path, additional_file = None):
+def read_genomes_list(genomes_path, additional_file = None, additional_quality_file = None,
+                      max_contamination = 5, min_completeness = 95, max_num_contigs = 200):
     genomes_map = {}
     total_genomes = 0
+    additional_quality = {}
     if additional_file is not None:
+        if additional_quality_file is None:
+            raise ValueError("Parameter additional_genomes_quality_file is required when additional_references is set")
+        additional_quality = read_additional_genomes_quality(additional_quality_file)
         with open(additional_file,'r') as add:
             for line in add:
+                if not line.strip():
+                    continue
                 ncbi_id, sci_name, path, novelty = line.strip().split('\t')
+                path_key = normalize_genome_key(path)
+                if path_key not in additional_quality:
+                    raise ValueError("Missing quality entry for additional genome '%s' in '%s'" % (path, additional_quality_file))
+                quality_entry = additional_quality[path_key]
+                genome_record = {
+                    "path": path,
+                    "novelty": novelty,
+                    "source": "additional",
+                    "quality_pass": meets_additional_quality_requirements(
+                        quality_entry,
+                        max_contamination,
+                        min_completeness,
+                        max_num_contigs
+                    )
+                }
                 if ncbi_id in genomes_map:
-                    genomes_map[ncbi_id][1].append(path)
+                    genomes_map[ncbi_id]["genomes"].append(genome_record)
                 else:
-                    genomes_map[ncbi_id] = (sci_name, [path], novelty) # this might not be a http path
+                    genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]}
                 total_genomes += 1
     with open(genomes_path,'r') as genomes:
         for line in genomes:
+            if not line.strip():
+                continue
             ncbi_id, sci_name, ftp = line.strip().split('\t')
             http = ftp.replace("ftp://","http://") # not using ftp address but http (proxies)
+            genome_record = {
+                "path": http,
+                "novelty": 'known_strain',
+                "source": "reference",
+                "quality_pass": True
+            }
             if ncbi_id in genomes_map:
-                genomes_map[ncbi_id][1].append(http)
+                genomes_map[ncbi_id]["genomes"].append(genome_record)
             else:
-                genomes_map[ncbi_id] = (sci_name, [http], 'known_strain') # sci_name is always the same for same taxid (?)
+                genomes_map[ncbi_id] = {"scientific_name": sci_name, "genomes": [genome_record]} # sci_name is always the same for same taxid (?)
             total_genomes += 1
     return genomes_map, total_genomes
 
@@ -89,6 +175,15 @@ def get_genomes_per_rank(genomes_map, ncbi):
         try:
             lineage = ncbi.get_lineage(genome) # this might contain some others ranks than ranks
             ranks_lin = ncbi.get_rank(lineage)
+            genome_records = []
+            for genome_record in genomes_map[genome]["genomes"]:
+                genome_records.append({
+                    "path": genome_record["path"],
+                    "genome_id": genome,
+                    "novelty": genome_record["novelty"],
+                    "source": genome_record["source"],
+                    "quality_pass": genome_record["quality_pass"]
+                })
             for tax_id in lineage: # go over the lineage
                 try:
                     check_rank = ranks_lin[tax_id]
@@ -98,8 +193,8 @@ def get_genomes_per_rank(genomes_map, ncbi):
                     rank_map = per_rank_map[ranks_lin[tax_id]]
                     if tax_id not in rank_map: # tax id doesn't have a genome yet
                         rank_map[tax_id] = []
-                    for strain in genomes_map[genome][1]:
-                        rank_map[tax_id].append((strain,genome)) # add http address
+                    for genome_record in genome_records:
+                        rank_map[tax_id].append(genome_record)
         except ValueError as e:
 #           log.warning(e)
             print(e) # ToDo
@@ -133,9 +228,10 @@ def transform_lineage(lineage, ncbi):
             if ncbi.get_rank([taxid])[taxid] in RANKS:
                 new_lineage.append(taxid) # should contain only one element
         else:
-            name = name.split()[0]
-            if name in mapping:
-                taxid = mapping[name][0]
+            fallback_name = name.split()[0]
+            fallback_mapping = ncbi.get_name_translator([fallback_name])
+            if fallback_name in fallback_mapping:
+                taxid = fallback_mapping[fallback_name][0]
                 if ncbi.get_rank([taxid])[taxid] in RANKS:
                     new_lineage.append(taxid) # retry if space in name destroys ID
     return new_lineage[::-1] # invert list, so lowest rank appears first (last in BIOM)
@@ -159,16 +255,38 @@ def truncated_geometric(p, l, u, max_tries=100000):
 def set_abundances(otu_genome_map, abundances, used_genomes, otu, tax_id, mu, sigma):
     log_normal_vals = np_rand.lognormal(mu, sigma, len(used_genomes))
     sum_log_normal = sum(log_normal_vals)
-    for i, (path, genome_id) in enumerate(used_genomes):
+    for i, genome in enumerate(used_genomes):
         otu_id = otu + "." + str(i)
-        otu_genome_map[otu_id] = (tax_id, genome_id, path, [])  # taxid, genomeid, http path, abundances per sample
+        otu_genome_map[otu_id] = (tax_id, genome["genome_id"], genome["path"], genome["novelty"], [])  # taxid, genomeid, http path, novelty, abundances per sample
         relative_abundance = log_normal_vals[i] / sum_log_normal
         for abundance in abundances:  # calculate abundance per sample
             current_abundance = relative_abundance * abundance
             otu_genome_map[otu_id][-1].append(current_abundance)
 
 
-def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace):
+def sample_genomes(genomes, amount):
+    if amount <= 0 or not genomes:
+        return []
+    draw_count = min(len(genomes), amount)
+    used_indices = np_rand.choice(len(genomes), draw_count, replace=False)
+    return [genomes[i] for i in used_indices]
+
+
+def get_candidate_groups(available_genomes, prioritize_additional_genomes):
+    high_quality_additional = [genome for genome in available_genomes if genome["source"] == "additional" and genome["quality_pass"]]
+    reference_genomes = [genome for genome in available_genomes if genome["source"] == "reference"]
+    low_quality_additional = [genome for genome in available_genomes if genome["source"] == "additional" and not genome["quality_pass"]]
+
+    if prioritize_additional_genomes:
+        candidate_groups = [high_quality_additional, reference_genomes]
+    else:
+        candidate_groups = [high_quality_additional + reference_genomes]
+
+    candidate_groups.append(low_quality_additional)
+    return candidate_groups
+
+
+def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace, prioritize_additional_genomes):
     rank = ncbi.get_rank([tax_id])[tax_id]
     if RANKS.index(rank) > RANKS.index(max_rank):
         return []
@@ -176,18 +294,19 @@ def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi,
     if not available_genomes:
         return []
     strains_to_draw = truncated_geometric(2. / max_strains, min_strains, max_strains)
-    if len(available_genomes) >= strains_to_draw:
-        used_indices = np_rand.choice(len(available_genomes), strains_to_draw, replace=False)
-        used_genomes = [available_genomes[i] for i in used_indices]
-    else:
-        used_genomes = available_genomes[:]  # if not enough genomes: use all
+    used_genomes = []
+    for candidate_group in get_candidate_groups(available_genomes, prioritize_additional_genomes):
+        remaining = strains_to_draw - len(used_genomes)
+        if remaining <= 0:
+            break
+        used_genomes.extend(sample_genomes(candidate_group, remaining))
 
     if no_replace: # sampling without replacement:
-        for path, genome_id in used_genomes:
+        for genome in used_genomes:
             for new_rank in per_rank_map:
                 for taxid in per_rank_map[new_rank]:
-                    if (path, genome_id) in per_rank_map[new_rank][taxid]:
-                        per_rank_map[new_rank][taxid].remove((path, genome_id))
+                    if genome in per_rank_map[new_rank][taxid]:
+                        per_rank_map[new_rank][taxid].remove(genome)
 
     return used_genomes
 
@@ -195,7 +314,8 @@ def pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi,
 """
 Given the OTU to lineage/abundances map and the genomes to lineage map, create map otu: taxid, genome, abundances
 """
-def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_strains, no_replace, max_genomes, max_rank, ncbi):
+def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_strains, no_replace,
+                        max_genomes, max_rank, prioritize_additional_genomes, ncbi):
     unmatched_otus = []
     matched_otus = set()
     otu_genome_map = {}
@@ -226,7 +346,8 @@ def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_s
             except IndexError:
                 continue
 
-            used_genomes = pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace)
+            used_genomes = pick_genomes(tax_id, max_rank, min_strains, max_strains, per_rank_map, ncbi, no_replace,
+                                        prioritize_additional_genomes)
             if not used_genomes:
                 continue
 
@@ -241,32 +362,36 @@ def map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma, min_strains, max_s
 
     return otu_genome_map, unmatched_otus
 
-def fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile, debug):
+def fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile, debug, prioritize_additional_genomes):
     genomes = {}
-    added_genomes = set()
     for rank in per_rank_map:
         for taxid in per_rank_map[rank]:
-            genomes[taxid] = []
-            for path, genome_id in per_rank_map[rank][taxid]:
-                if path not in added_genomes:
-                    genomes[taxid].append((path, genome_id))
-                    added_genomes.add(path)
+            for genome in per_rank_map[rank][taxid]:
+                genome_key = (genome["path"], genome["genome_id"])
+                if genome_key not in genomes:
+                    genomes[genome_key] = {
+                        "tax_id": taxid,
+                        "genome_id": genome["genome_id"],
+                        "path": genome["path"],
+                        "novelty": genome["novelty"],
+                        "source": genome["source"],
+                        "quality_pass": genome["quality_pass"]
+                    }
+
+    ordered_genomes = []
+    for candidate_group in get_candidate_groups(list(genomes.values()), prioritize_additional_genomes):
+        ordered_genomes.extend(sample_genomes(candidate_group, len(candidate_group)))
+
+    if not ordered_genomes:
+        return otu_genome_map
+
     otu_indices = np_rand.choice(len(unmatched_otus),len(unmatched_otus),replace=False)
-    i = 0
-    set_all = False
-    for tax_id in genomes:
-        for path, genome_id in genomes[tax_id]:
-            curr_otu = unmatched_otus[otu_indices[i]] #so we choose a random genome
-            lineage, abundances = tax_profile[curr_otu]
-            otu_genome_map[curr_otu] = (tax_id, genome_id, path, abundances)
-#            if debug:
-#                _log.warning("Filling up OTU %s (mapped tax id: %s) to genome with tax id %s" % (curr_otu, lin[0], tax_id))
-            i += 1
-            if (i >= len(unmatched_otus) or i >= len(added_genomes)):
-                set_all = True
-                break
-        if (set_all):
-            break
+    for i, genome in enumerate(ordered_genomes[:len(unmatched_otus)]):
+        curr_otu = unmatched_otus[otu_indices[i]] #so we choose a random genome
+        lineage, abundances = tax_profile[curr_otu]
+        otu_genome_map[curr_otu] = (genome["tax_id"], genome["genome_id"], genome["path"], genome["novelty"], abundances)
+#        if debug:
+#            _log.warning("Filling up OTU %s (mapped tax id: %s) to genome with tax id %s" % (curr_otu, lin[0], tax_id))
     return otu_genome_map
 
 """
@@ -305,7 +430,7 @@ def download_genome(genome, out_path, script):
 """
 Given the created maps and the old config files, creates the required files and new config
 """
-def write_config(otu_genome_map, genomes_map, no_samples, script, out_path_genomes):
+def write_config(otu_genome_map, no_samples, script, out_path_genomes):
     out_path = "./"
     genome_to_id = os.path.join(out_path, "genome_to_id.tsv")
     #config.set('community0','id_to_genome_file', genome_to_id)
@@ -323,7 +448,7 @@ def write_config(otu_genome_map, genomes_map, no_samples, script, out_path_genom
     if not os.path.exists(create_path):
         os.makedirs(create_path)
     for otu in otu_genome_map:
-        taxid, genome_id, path, curr_abundances = otu_genome_map[otu]
+        taxid, genome_id, path, novelty, curr_abundances = otu_genome_map[otu]
         counter = 0
         while counter < 10:
             try:
@@ -345,7 +470,6 @@ def write_config(otu_genome_map, genomes_map, no_samples, script, out_path_genom
         with open(genome_to_id,'a+') as gid:
             gid.write("%s\t%s\n" % (otu, genome_path))
         with open(metadata,'a+') as md:
-            novelty = genomes_map[genome_id][-1]
             md.write("%s\t%s\t%s\t%s\n" % (otu,taxid,genome_id,novelty))
         i = 0
         for abundance in abundances:
@@ -376,10 +500,14 @@ def set_ranks(ncbi):
 
 def main(biom_profile, no_samples, reference_genomes, seed, mu, sigma,
          min_strains,  max_strains, debug, no_replace, fill_up, script,
-         genomes_out_dir, additional_references, ncbi_taxdump_file, max_rank):
+         genomes_out_dir, additional_references, additional_genomes_quality_file, ncbi_taxdump_file,
+         max_rank, prioritize_additional_genomes, additional_genomes_max_contamination,
+         additional_genomes_min_completeness, additional_genomes_max_num_contigs):
 
     if additional_references == "None":
         additional_references = None
+    if additional_genomes_quality_file == "None":
+        additional_genomes_quality_file = None
 
     np_rand.seed(seed)
 
@@ -387,16 +515,22 @@ def main(biom_profile, no_samples, reference_genomes, seed, mu, sigma,
     set_ranks(ncbi)
 
     tax_profile = read_taxonomic_profile(biom_profile, no_samples)
-    genomes_map, total_genomes = read_genomes_list(reference_genomes, additional_references)
+    genomes_map, total_genomes = read_genomes_list(reference_genomes, additional_references,
+                                                   additional_genomes_quality_file,
+                                                   additional_genomes_max_contamination,
+                                                   additional_genomes_min_completeness,
+                                                   additional_genomes_max_num_contigs)
     per_rank_map = get_genomes_per_rank(genomes_map, ncbi)
     otu_genome_map, unmatched_otus = map_otus_to_genomes(tax_profile, per_rank_map, mu, sigma,
                                                          min_strains, max_strains, no_replace,
-                                                         total_genomes, max_rank, ncbi)
+                                                         total_genomes, max_rank,
+                                                         prioritize_additional_genomes, ncbi)
 
     if fill_up and len(unmatched_otus) > 0:
-        otu_genome_map = fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile, debug)
+        otu_genome_map = fill_up_genomes(otu_genome_map, unmatched_otus, per_rank_map, tax_profile,
+                                         debug, prioritize_additional_genomes)
 
-    write_config(otu_genome_map, genomes_map, no_samples, script, genomes_out_dir)
+    write_config(otu_genome_map, no_samples, script, genomes_out_dir)
 
 
 if __name__ == "__main__":
@@ -414,5 +548,10 @@ if __name__ == "__main__":
         script = sys.argv[12],
         genomes_out_dir = sys.argv[13],
         additional_references = sys.argv[14],
-        ncbi_taxdump_file = sys.argv[15],
-        max_rank = sys.argv[16])
+        additional_genomes_quality_file = sys.argv[15],
+        ncbi_taxdump_file = sys.argv[16],
+        max_rank = sys.argv[17],
+        prioritize_additional_genomes = str2bool(sys.argv[18]),
+        additional_genomes_max_contamination = float(sys.argv[19]),
+        additional_genomes_min_completeness = float(sys.argv[20]),
+        additional_genomes_max_num_contigs = int(float(sys.argv[21])))

--- a/pipelines/shared/scripts/get_community_distribution.py
+++ b/pipelines/shared/scripts/get_community_distribution.py
@@ -569,12 +569,13 @@ def write_distribution_file(stream_out, genome_id_to_abundance, sample_index):
 			stream_out.write("{id}\t{distr}\n".format(id=genome_id, distr=distribution))
 
 def str_to_bool(s):
-	if s == 'True':
+	value = str(s).strip().lower()
+	if value in ('true', '1', 'yes', 'y'):
 		return True
-	elif s == 'False':
+	elif value in ('false', '0', 'no', 'n'):
 		return False
 	else:
-		raise ValueError("Flag 'verbose' must either be set to True or False.")
+		raise ValueError("Flag 'verbose' must be a boolean value such as true/false.")
 
 def get_distribution_file_paths(directory, number_of_samples):
         """


### PR DESCRIPTION
This PR hardens the profile-driven metagenomic workflow around `get_genomes.py` and related Nextflow plumbing. The main goals are to support curated additional genomes with explicit quality gating, preserve the existing rank-first matching logic while adding source prioritization within a matched taxon, make profile-only community-design runs publish the expected core outputs, and fix several robustness issues observed in real runs.

Compared with `dev`, this branch changes the following files:

- `.gitignore`
- `convert_config.py`
- `nextflow.config`
- `pipelines/metagenomic/config/distribution.config`
- `pipelines/metagenomic/config/metagenomic.config`
- `pipelines/metagenomic/config/profile.config`
- `pipelines/metagenomic/from_profile.nf`
- `pipelines/metagenomic/metagenomic.nf`
- `pipelines/metagenomic/scripts/clean_up_sequences.py`
- `pipelines/metagenomic/scripts/get_genomes.py`
- `pipelines/shared/scripts/get_community_distribution.py`

## What changed

### 1. Make external config loading work reliably from outside the repo

File changed: `nextflow.config`

- Add `resolveExternalConfigPath(...)` and use it for `params.config`.
- Resolve config paths in this order:
  1. absolute path as provided
  2. relative to the launch directory
  3. relative to `projectDir` as a backward-compatible fallback
- Fail with a clear error if the external config file cannot be found in any of those locations.

Reason:
- Running `nextflow run ../pipeline/CAMISIM/main.nf --config ./some_config` from another working directory was brittle because config resolution depended on pipeline-relative paths.

### 2. Add profile-mode parameters for curated additional genomes and wire them through the workflow

Files changed:
- `convert_config.py`
- `pipelines/metagenomic/config/profile.config`
- `pipelines/metagenomic/from_profile.nf`

Changes:
- Add support for the following profile-mode parameters:
  - `prioritize_additional_genomes`
  - `additional_genomes_quality_file`
  - `additional_genomes_max_contamination`
  - `additional_genomes_min_completeness`
  - `additional_genomes_max_num_contigs`
- Update `convert_config.py` to emit these parameters and normalize boolean/string handling for them.
- Update `from_profile.nf` to provide explicit defaults for profile-only params when an external config does not import `profile.config`.
- Pass the new additional-genome selection and quality-threshold parameters into `get_genomes.py`.
- Guard `additional_references` access with `params.containsKey(...)` so profile runs do not crash when the parameter is absent.
- Extend `profile.config` comments to document accepted `additional_references` formats and the new quality-driven selection behavior.

Reason:
- The workflow previously assumed profile-specific params were always present, and it did not support quality-aware prioritization of additional genomes.

### 3. Preserve rank-first matching while adding source-aware genome selection

File changed: `pipelines/metagenomic/scripts/get_genomes.py`

Changes:
- Keep the existing taxonomy matching strategy: attempt the most specific resolved rank first, then move to broader ranks only if needed.
- Add source-aware candidate grouping within a matched taxon:
  - if `prioritize_additional_genomes = true`, draw from high-quality additional genomes first, then public reference genomes, then low-quality additional genomes as last resort
  - if `false`, draw from high-quality additional genomes and public references together, then use low-quality additional genomes only after the preferred pool is exhausted
- Apply the same candidate ordering in the `fill_up` fallback path.
- Require `additional_genomes_quality_file` when `additional_references` is set.
- Parse quality TSVs with required columns `genome_path`, `completeness`, `contamination`, and `num_contigs`.
- Mark additional genomes as quality-passing or low-quality based on configured thresholds.

Reason:
- This keeps taxonomic specificity as the primary priority while allowing curated genomes to be preferred within the same matched rank.

### 4. Make additional-genome and reference-genome table parsing more robust

File changed: `pipelines/metagenomic/scripts/get_genomes.py`

Changes:
- Add header-aware parsing for genome tables with alias support for common column names.
- Accept both 3-column and 4-column `additional_references` files:
  - `ncbi_taxid`, `scientific_name`, `genome_path`
  - `ncbi_taxid`, `scientific_name`, `genome_path`, `novelty_category`
- Default `novelty_category` to `known_strain` when omitted.
- Normalize genome-path keys when matching additional genomes to their quality TSV entries.

Reason:
- Real input files were failing on valid 3-column TSVs and on files with headers or alternative column names.

### 5. Fix taxonomy-name fallback and improve compatibility with installed ETE versions

File changed: `pipelines/metagenomic/scripts/get_genomes.py`

Changes:
- Fix the lineage-resolution fallback so that when exact NCBI name translation fails, the retry with the first token performs a real second translator lookup.
- Add a fallback import from `ete4` to `ete3` for `NCBITaxa`.

Reason:
- The previous retry branch reused stale lookup results and could silently drop recoverable ranks.
- Some environments had `ete3` available but not `ete4`, causing the profile workflow to fail before matching started.

### 6. Fix strain-count handling for profile mode

Files changed:
- `pipelines/metagenomic/scripts/get_genomes.py`
- `pipelines/metagenomic/config/metagenomic.config`

Changes:
- Validate `min_strains_per_otu` and `max_strains_per_otu` bounds explicitly.
- Add `draw_num_strains(...)` to handle edge cases cleanly.
- Preserve the previous geometric-style draw for larger ranges, but use a bounded uniform draw for small ranges where the old logic was pathological.
- Update config comments to reflect that `max_strains_per_otu = 1` is valid in profile mode.

Reason:
- The old draw logic behaved incorrectly for small ranges, especially `min=1, max=2`, and did not explicitly guard invalid bounds.

### 7. Publish the expected community-design outputs even when `just_community_design = true`

File changed: `pipelines/metagenomic/from_profile.nf`

Changes:
- Create `outdir/distributions/` during profile-mode genome selection.
- Copy `abundance_*.tsv` into `outdir/distributions/`.
- Copy `genome_to_id.tsv` into both:
  - `outdir/internal/genome_to_id.tsv`
  - `outdir/internal/genome_locations.tsv`

Reason:
- In profile mode, `just_community_design = true` stopped the workflow early before these files were published, which made the output layout incomplete for downstream reuse.

### 8. Prevent genome filename collisions when many input FASTAs share the same basename

Files changed:
- `pipelines/metagenomic/scripts/get_genomes.py`
- `pipelines/metagenomic/metagenomic.nf`
- `pipelines/metagenomic/scripts/clean_up_sequences.py`

Changes in `get_genomes.py`:
- Derive copied/downloaded genome filenames from the scientific label plus the source basename.
- Sanitize filenames and append numeric suffixes on collision.
- Preserve deterministic naming within a run.

Changes in `metagenomic.nf`:
- Pass full `[genome_id, path]` entries into `cleanup_and_filter_sequences` instead of flattening to basenames.
- Build an absolute temporary mapping file for cleanup rather than relying on staged filenames.

Changes in `clean_up_sequences.py`:
- Open genomes from their real full paths.
- Generate unique output names when different input genomes share the same basename, such as repeated `genomic.fna`.
- Write the remapped internal TSV against the renamed output files.

Reason:
- The workflow previously collided on shared basenames and could fail or mis-map genomes when multiple different source files had the same filename.

### 9. Improve `get_genomes.py` performance without changing the intended matching output

File changed: `pipelines/metagenomic/scripts/get_genomes.py`

Changes:
- Cache taxonomy name-to-taxid lookups.
- Cache taxid-to-rank lookups.
- Build reverse bucket indices so `no_replace` removal does not scan every rank/taxon bucket repeatedly.
- Stream writes to `genome_to_id.tsv`, `metadata.tsv`, and `abundance_*.tsv` instead of reopening files for every OTU.

Reason:
- `get_genomes.py` was noticeably slow on larger profiles, and the previous removal and file-writing paths had avoidable overhead.

### 10. Normalize boolean handling for community-distribution verbosity

Files changed:
- `pipelines/shared/scripts/get_community_distribution.py`
- `pipelines/metagenomic/config/distribution.config`

Changes:
- Accept case-insensitive boolean-like values for `verbose`, including `true/false`, `True/False`, `1/0`, and `yes/no`.
- Update the default config value from `"False"` to `false`.

Reason:
- The parser previously only accepted literal string values `True` and `False`, which was inconsistent with the rest of the Nextflow configs.

### 11. Ignore local run-specific config files in Git

File changed: `.gitignore`

Changes:
- Ignore:
  - `configs/`
  - `camisim.cfg`
  - `metax_bench_data.config`

Reason:
- These are local run/config artifacts that should not be picked up as repository changes.

### 12. Correct `*,cover` in `.gitignore`

File changed: `.gitignore`

Changes:
- From `*,cover` to `*.cover`

Reason:
- "," was a typo.
